### PR TITLE
Add Makevars.win

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,0 +1,1 @@
+CXX_STD=CXX17


### PR DESCRIPTION
I think this may fix the build failures on Windows :) 

You'll need to trigger the GHA workflows manually to find out.