### PR TITLE
Added `n_threads` argument to `sample_posterior` methods.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,8 @@ Imports:
     Rcpp,
     methods,
     Rdpack,
-    R6
+    R6,
+    parallel
 RdMacros: Rdpack
 Suggests:
     covr,

--- a/man/dirichlet_tree.Rd
+++ b/man/dirichlet_tree.Rd
@@ -253,7 +253,12 @@ posterior, then determines the probability for each candidate being
 elected by aggregating the results of the social choice function. See
 \insertCite{dtree_evoteid;textual}{elections.dtree} for details.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{dirichlet_tree$sample_posterior(n_elections, n_ballots, n_winners = 1)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{dirichlet_tree$sample_posterior(
+  n_elections,
+  n_ballots,
+  n_winners = 1,
+  n_threads = NULL
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -265,6 +270,11 @@ number yields higher precision in the output probabilities.}
 \item{\code{n_ballots}}{An integer representing the total number of ballots cast in the election.}
 
 \item{\code{n_winners}}{The number of candidates elected in each election.}
+
+\item{\code{n_threads}}{The maximum number of threads for the process. The default value of
+\code{NULL} will default to 2 threads. \code{Inf} will default to the maximum
+available, and any value greater than or equal to the maximum available will
+result in the maximum available.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/sample_posterior.Rd
+++ b/man/sample_posterior.Rd
@@ -4,7 +4,13 @@
 \alias{sample_posterior}
 \title{Draw election outcomes from the posterior distribution.}
 \usage{
-sample_posterior(dtree, n_elections, n_ballots, n_winners = 1)
+sample_posterior(
+  dtree,
+  n_elections,
+  n_ballots,
+  n_winners = 1,
+  n_threads = NULL
+)
 }
 \arguments{
 \item{dtree}{A \code{dirichlet_tree} object.}
@@ -15,6 +21,11 @@ number yields higher precision in the output probabilities.}
 \item{n_ballots}{An integer representing the total number of ballots cast in the election.}
 
 \item{n_winners}{The number of candidates elected in each election.}
+
+\item{n_threads}{The maximum number of threads for the process. The default value of
+\code{NULL} will default to 2 threads. \code{Inf} will default to the maximum
+available, and any value greater than or equal to the maximum available will
+result in the maximum available.}
 }
 \value{
 A numeric vector containing the probabilities for each candidate

--- a/src/R_tree.h
+++ b/src/R_tree.h
@@ -90,7 +90,7 @@ public:
   void update(Rcpp::List ballots);
   Rcpp::List samplePredictive(unsigned nSamples, std::string seed);
   Rcpp::NumericVector samplePosterior(unsigned nElections, unsigned nBallots,
-                                      unsigned nWinners, unsigned nBatches,
+                                      unsigned nWinners, unsigned nThreads,
                                       std::string seed);
 };
 

--- a/tests/testthat/test-posterior.R
+++ b/tests/testthat/test-posterior.R
@@ -32,3 +32,28 @@ test_that("Posterior cannot be calculated when n_ballots is too low", {
     sample_posterior(dtree, 1, 1)
   })
 })
+
+test_that("Posterior cannot be calculated with invalid `n_elections`", {
+  dtree <- dirtree(candidates = LETTERS[1:3])
+  expect_error({
+    sample_posterior(dtree, 0, 1)
+  })
+})
+
+test_that("Exception is thrown with invalid `n_threads`", {
+  dtree <- dirtree(candidates = LETTERS[1:3])
+  expect_error({
+    sample_posterior(dtree, 2, 2, n_threads = 0)
+  })
+})
+
+test_that("No exception is thrown with `n_threads` > maximum available", {
+  skip_on_cran() # Exceeds maximum number of cores
+  dtree <- dirtree(candidates = LETTERS[1:3])
+  expect_true(any(sample_posterior(dtree, 2, 2, n_threads = Inf) > 0))
+  expect_true(
+    any(sample_posterior(dtree, 2, 2,
+      n_threads = parallel::detectCores() + 1
+    ) > 0)
+  )
+})


### PR DESCRIPTION
* Added an argument `n_threads` to `sample_posterior`.
* Defaults to limit the number of threads to 2. This is to adhere to CRAN requirements.